### PR TITLE
Remove unnecessary redirection

### DIFF
--- a/jsonxx/jsonxx.h
+++ b/jsonxx/jsonxx.h
@@ -6,7 +6,7 @@
 //   rlyeh <https://github.com/r-lyeh>
 
 #pragma once
-#include "..\..\GH-Offset-Dumper\stdafx.h"
+#include "..\stdafx.h"
 #include <cstddef>
 #include <cassert>
 #include <iostream>


### PR DESCRIPTION
on rename the project dir, the project didn't compile. 
Remove unnecessary redirection